### PR TITLE
fix: json-utf8-sanitize

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wireplumber (0.5.14-1deepin4) unstable; urgency=medium
+
+  * fix: Json-utf8-sanitize
+
+ -- liujiahe <liujiahe@uniontech.com>  Fri, 26 Jun 2026 16:29:49 +0800
+
 wireplumber (0.5.14-1deepin3) unstable; urgency=medium
 
   * Fix Lua GC crash on exit.

--- a/debian/patches/Fix-json-utf8-sanitize.patch
+++ b/debian/patches/Fix-json-utf8-sanitize.patch
@@ -1,0 +1,97 @@
+Index: my-wireplumber/src/scripts/default-nodes/rescan.lua
+===================================================================
+--- my-wireplumber.orig/src/scripts/default-nodes/rescan.lua
++++ my-wireplumber/src/scripts/default-nodes/rescan.lua
+@@ -11,6 +11,78 @@ lutils = require ("linking-utils")
+ 
+ log = Log.open_topic ("s-default-nodes")
+ 
++-- Sanitize a string so it is valid UTF-8, replacing invalid sequences with
++-- the Unicode replacement character (U+FFFD). WirePlumber's JSON serializer
++-- crashes on property values that contain invalid UTF-8 bytes (observed on
++-- HDMI nodes where api.alsa.card.longname contains garbage bytes).
++local REPLACEMENT = "\xEF\xBF\xBD"
++local function sanitize_utf8 (s)
++  local out = {}
++  local i = 1
++  local n = #s
++  while i <= n do
++    local c = s:byte (i)
++    if c < 0x80 then
++      out [#out + 1] = s:sub (i, i)
++      i = i + 1
++    elseif c < 0xC0 then
++      -- stray continuation byte
++      out [#out + 1] = REPLACEMENT
++      i = i + 1
++    elseif c < 0xE0 then
++      -- 2-byte sequence
++      if i + 1 <= n then
++        local c2 = s:byte (i + 1)
++        if c2 >= 0x80 and c2 < 0xC0 then
++          out [#out + 1] = s:sub (i, i + 1)
++          i = i + 2
++        else
++          out [#out + 1] = REPLACEMENT
++          i = i + 1
++        end
++      else
++        out [#out + 1] = REPLACEMENT
++        i = i + 1
++      end
++    elseif c < 0xF0 then
++      -- 3-byte sequence
++      if i + 2 <= n then
++        local c2, c3 = s:byte (i + 1, i + 2)
++        if c2 >= 0x80 and c2 < 0xC0 and c3 >= 0x80 and c3 < 0xC0 then
++          out [#out + 1] = s:sub (i, i + 2)
++          i = i + 3
++        else
++          out [#out + 1] = REPLACEMENT
++          i = i + 1
++        end
++      else
++        out [#out + 1] = REPLACEMENT
++        i = i + 1
++      end
++    elseif c < 0xF8 then
++      -- 4-byte sequence
++      if i + 3 <= n then
++        local c2, c3, c4 = s:byte (i + 1, i + 3)
++        if c2 >= 0x80 and c2 < 0xC0 and c3 >= 0x80 and c3 < 0xC0 and
++           c4 >= 0x80 and c4 < 0xC0 then
++          out [#out + 1] = s:sub (i, i + 3)
++          i = i + 4
++        else
++          out [#out + 1] = REPLACEMENT
++          i = i + 1
++        end
++      else
++        out [#out + 1] = REPLACEMENT
++        i = i + 1
++      end
++    else
++      out [#out + 1] = REPLACEMENT
++      i = i + 1
++    end
++  end
++  return table.concat (out)
++end
++
+ -- looks for changes in user-preferences and devices added/removed and schedules
+ -- rescan
+ SimpleEventHook {
+@@ -113,7 +185,12 @@ function collectAvailableNodes (si_om, d
+       goto next_linkable
+     end
+ 
+-    table.insert (collected, Json.Object (node_props))
++    -- sanitize property values to avoid JSON serializer crashes on invalid UTF-8
++    local sanitized_props = {}
++    for k, v in pairs (node_props) do
++      sanitized_props[k] = sanitize_utf8 (v)
++    end
++    table.insert (collected, Json.Object (sanitized_props))
+ 
+     ::next_linkable::
+   end

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ Fix-Optimize-the-volume-algorithm.patch
 0003-module-Call-parent-s-destructor-before-finalizing.patch
 0004-m-lua-scripting-Deactivate-all-scripts-before-deacti.patch
 0005-registry-Deactivate-all-objects-before-clearing-the-.patch
+Fix-json-utf8-sanitize.patch


### PR DESCRIPTION
Log:
scripts: default-nodes: sanitize UTF-8 before JSON serialization

Some hardware reports ALSA card long names with invalid UTF-8 byte sequences (e.g. GBK/GB2312 encoded Chinese characters). This causes Json.Object() serialization to fail, which drops the affected node from the available-nodes list in the select-default-node event.

As a result, users cannot switch to HDMI sinks even though the device appears in `wpctl status`.

Add sanitize_utf8() to replace invalid UTF-8 sequences with the Unicode replacement character (U+FFFD) before passing properties to Json.Object(). This ensures JSON serialization succeeds and the HDMI node remains in the candidate list.