### PR TITLE
fix(state-stream): only use media.role key for notification role

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wireplumber (0.5.14-1deepin5) unstable; urgency=medium
+
+  * Only use 'media.role' key if its value is 'Notification' when
+    forming key in state-stream
+
+ -- deepin-ci-robot <packages@deepin.org>  Fri, 03 Jul 2026 18:13:06 +0800
+
 wireplumber (0.5.14-1deepin4) unstable; urgency=medium
 
   * fix: Json-utf8-sanitize

--- a/debian/patches/fix-state-stream-media-role-notification-only.patch
+++ b/debian/patches/fix-state-stream-media-role-notification-only.patch
@@ -1,0 +1,52 @@
+From 48c7a1aa186ae46e53710c5b57945d46e727ad14 Mon Sep 17 00:00:00 2001
+From: Julian Bouzas <julian.bouzas@collabora.com>
+Date: Thu, 4 Jun 2026 08:43:04 -0400
+Subject: [PATCH] state-stream: Only use 'media.role' key if its value is
+ 'Notification' when forming key
+
+This avoids different applications sharing the same role to have the same volume
+at startup, unless those are part of the Notification role.
+
+Fixes #955
+
+diff --git a/src/scripts/node/state-stream.lua b/src/scripts/node/state-stream.lua
+index 6587f26b..652d97a2 100644
+--- a/src/scripts/node/state-stream.lua
++++ b/src/scripts/node/state-stream.lua
+@@ -399,7 +399,6 @@ end
+ 
+ function formKey (properties)
+   local keys = {
+-    "media.role",
+     "application.id",
+     "application.name",
+     "media.name",
+@@ -407,14 +406,22 @@ function formKey (properties)
+   }
+   local key_base = nil
+ 
+-  for _, k in ipairs (keys) do
+-    local p = properties [k]
+-    if p then
+-      key_base = string.format ("%s:%s:%s",
+-          properties ["media.class"]:gsub ("^Stream/", ""), k, p)
+-      break
++  -- Only use the media.role key if it is set to Notification, otherwise use
++  -- the application keys.
++  if properties["media.role"] == "Notification" then
++    key_base = string.format ("%s:%s",
++        properties ["media.class"]:gsub ("^Stream/", ""), "media.role:Notification")
++  else
++    for _, k in ipairs (keys) do
++      local p = properties [k]
++      if p then
++        key_base = string.format ("%s:%s:%s",
++            properties ["media.class"]:gsub ("^Stream/", ""), k, p)
++        break
++      end
+     end
+   end
++
+   return key_base
+ end
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -6,3 +6,4 @@ Fix-Optimize-the-volume-algorithm.patch
 0004-m-lua-scripting-Deactivate-all-scripts-before-deacti.patch
 0005-registry-Deactivate-all-objects-before-clearing-the-.patch
 Fix-json-utf8-sanitize.patch
+fix-state-stream-media-role-notification-only.patch


### PR DESCRIPTION
## Problem Before the Change

In `src/scripts/node/state-stream.lua`, the `formKey()` function always used the
`media.role` property as the first key when forming the state key for stream
volume restoration. This meant that any applications sharing the same
`media.role` value would collide on the same state key, causing them to share
the same volume at startup even though they are distinct applications.

## What This PR Changes

The `formKey()` function is reworked so that `media.role` is no longer part of
the generic keys list. Instead, `media.role` is only used when its value is
exactly `Notification`; otherwise the application-based keys
(`application.id`, `application.name`, `media.name`, `node.name`) are used to
build the key, keeping per-application volume state independent.

## Problem Solved After the Change

Different applications that share a non-Notification `media.role` no longer
have their startup volume overwritten by one another. Only streams belonging to
the `Notification` role continue to share a common key, which is the desired
behavior.

## Changes

- Add debian/patches/fix-state-stream-media-role-notification-only.patch
- Modify debian/patches/series
- Modify debian/changelog

## Upstream

[pipewire/wireplumber@48c7a1aa](https://gitlab.freedesktop.org/pipewire/wireplumber/-/commit/48c7a1aa186ae46e53710c5b57945d46e727ad14)

Generated-By: glm-5.2
Co-Authored-By: deepin-ci-robot <packages@deepin.org>
